### PR TITLE
add 'deploy to heroku button'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This app makes it easy to test out koop functionality, as well as to add additio
 
 If you're new to node development, you can find more information about setting up a development environment [here](docs/SET_UP.md)
 
-##Instructions
+## Instructions
 
 1. copy down the repository to your own machine
 ```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "Koop Sample App",
+  "description": "boilerplate Koop app suitable for deployment to Heroku",
+  "repository": "https://github.com/koopjs/koop-sample-app",
+  "logo": "https://avatars1.githubusercontent.com/u/11509517",
+  "keywords": ["node", "express", "static"]
+}

--- a/docs/DEPLOY_TO_HEROKU.md
+++ b/docs/DEPLOY_TO_HEROKU.md
@@ -1,9 +1,12 @@
 # Deploying to Heroku
 
-need instructions here
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/koopjs/koop-sample-app)
+
+or, if you like doing things manually, feel free to check out out the information in the [Heroku Dev Center](https://devcenter.heroku.com/articles/getting-started-with-nodejs#deploy-the-app)
 
 # Deploying to Heroku (w/ PostGIS)
 
 you can find general information about configuring PostGIS for koop [here](PG_CACHE.md)
 
-need instructions for getting PostGIS up and running and referenced appropriately in koop's config here
+### to do
+include instructions for getting PostGIS up and running and referenced appropriately in koop's config here


### PR DESCRIPTION
as per @ngoldman's suggestion, i added an app.json file to the project so we can include a nifty *Deploy to Heroku* button.

https://github.com/jgravois/koop-sample-app/blob/heroku-doc/docs/DEPLOY_TO_HEROKU.md

obviously its going to be more important (and more complicated) to enhance support to include provisioning the PostGIS instance, but one step at a time...

happy to squash once everyone else is.