### PR TITLE
clean & refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,41 @@
-# Koop-Sample-App
-a sample express application intended to show how to deploy an instance of koop together with some koop providers.
+# Koop Sample App
 
-This app makes it easy to test out koop functionality, as well as to add additional koop providers for testing or deployment.
+A sample [koop](https://github.com/esri/koop) express application with some common [koop providers](https://github.com/Esri/koop/wiki/Koop-Providers-(an-ecosystem)).
 
-If you're new to node development, you can find more information about setting up a development environment [here](docs/SET_UP.md)
+This app makes it easy to get started running your own instance of koop. It's also useful for trying out koop's functionality, trying new koop providers, and testing deployments.
+
+If you're new to [node](https://nodejs.org/) development, you can find more information about setting up a development environment [here](docs/SET_UP.md).
 
 ## Instructions
 
-1. copy down the repository to your own machine
-```
-git clone https://github.com/koopjs/koop-sample-app
-```
-2. navigate into your new folder
-```
-cd koop-sample-app
-```
-3. install koop's dependencies
-```
-npm install
-```
-4. take koop for a test drive
-```
-node server.js
-```
-5. you can try fetching a resource directly in the browser to confirm koop is running
-[http://localhost:1337/github/benbalter/dc-wifi-social/bars/](http://localhost:1337/github/benbalter/dc-wifi-social/bars/)
+1. Clone this repository on your machine.
 
-##Additional documentation
+  ```
+  git clone git@github.com:ngoldman/koop-sample-app.git
+  ```
+
+2. Change the working directory to the newly created `koop-sample-app` folder.
+
+  ```
+  cd koop-sample-app
+  ```
+
+3. Install koop's dependencies.
+
+  ```
+  npm install
+  ```
+
+4. Start the server.
+
+  ```
+  npm start
+  ```
+
+5. Take koop for a test drive!
+  You can try fetching a resource directly in the browser (such as http://localhost:1337/github/benbalter/dc-wifi-social/bars/) to confirm koop is running.
+
+## Additional documentation
+
 * [Configuring a persistent PostGIS cache](docs/PG_CACHE.md)
 * [Deploying to Heroku](docs/DEPLOY_TO_HEROKU.md)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're new to [node](https://nodejs.org/) development, you can find more info
 1. Clone this repository on your machine.
 
   ```
-  git clone git@github.com:ngoldman/koop-sample-app.git
+  git clone git@github.com:koopjs/koop-sample-app.git
   ```
 
 2. Change the working directory to the newly created `koop-sample-app` folder.
@@ -33,7 +33,7 @@ If you're new to [node](https://nodejs.org/) development, you can find more info
   ```
 
 5. Take koop for a test drive!
-  You can try fetching a resource directly in the browser (such as http://localhost:1337/github/benbalter/dc-wifi-social/bars/) to confirm koop is running.
+  You can try fetching a resource directly in the browser (such as [localhost:1337/github/benbalter/dc-wifi-social/bars/](http://localhost:1337/github/benbalter/dc-wifi-social/bars/)) to confirm koop is running.
 
 ## Additional documentation
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,9 +1,9 @@
 {
-    "server": {
-        "port": 1337
-    },
-    "data_dir": "/usr/local/koop/",
-    "db": {
-      "conn": "postgres://localhost/koopdev"
-    }
+  "server": {
+    "port": 1337
+  },
+  "data_dir": "/usr/local/koop/",
+  "db": {
+    "conn": "postgres://localhost/koopdev"
+  }
 }

--- a/config/default_https.json
+++ b/config/default_https.json
@@ -1,16 +1,14 @@
 {
-    "server": {
-        "port": 1337
-    },
-	
-	"https_server": {
-		"port": 1443,
-		"private_key" : "cert/private.pem",
-		"public_key" : "cert/public.pem"
-	 },	
-
-    "data_dir": "/usr/local/koop/",
-    "db": {
-      "conn": "postgres://localhost/koopdev"
-    }
+  "server": {
+    "port": 1337
+  },
+  "https_server": {
+    "port": 1443,
+    "private_key" : "cert/private.pem",
+    "public_key" : "cert/public.pem"
+  },
+  "data_dir": "/usr/local/koop/",
+  "db": {
+    "conn": "postgres://localhost/koopdev"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,19 +7,19 @@
     "url": "https://github.com/koopjs/koop-sample-app/issues"
   },
   "dependencies": {
-    "config": "~1.12.0",
+    "config": "^1.13.0",
     "cors": "^2.5.3",
     "ejs": "^2.3.1",
-    "express": "4.12.3",
+    "express": "^4.12.3",
     "koop": "^2.0.1",
-    "koop-agol": "^0.1.61",
-    "koop-ckan": "~0.0.8",
-    "koop-climate": "~0.0.2",
-    "koop-cloudant": "~0.0.3",
-    "koop-gist": "~0.0.2",
-    "koop-github": "~0.1.12",
-    "koop-pgcache": "~0.0.1",
-    "koop-socrata": "~0.0.9"
+    "koop-agol": "^0.2.0",
+    "koop-ckan": "^0.0.8",
+    "koop-climate": "^0.0.2",
+    "koop-cloudant": "^0.0.3",
+    "koop-gist": "^0.0.2",
+    "koop-github": "^0.1.12",
+    "koop-pgcache": "^0.1.0",
+    "koop-socrata": "^0.1.1"
   },
   "homepage": "https://github.com/koopjs/koop-sample-app",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,17 +1,10 @@
 {
   "name": "koop-sample-app",
+  "description": "A sample koop express application with some common koop providers.",
   "version": "1.0.3",
-  "description": "A sample application that shows how to create an app using koop ",
-  "main": "server.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
-  },
   "author": "Chris Helm",
-  "license": "ISC",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com:koopjs/koop-sample-app.git"
+  "bugs": {
+    "url": "https://github.com/koopjs/koop-sample-app/issues"
   },
   "dependencies": {
     "config": "~1.12.0",
@@ -25,7 +18,30 @@
     "koop-cloudant": "~0.0.3",
     "koop-gist": "~0.0.2",
     "koop-github": "~0.1.12",
-    "koop-socrata": "~0.0.9",
-    "koop-pgcache": "~0.0.1"
+    "koop-pgcache": "~0.0.1",
+    "koop-socrata": "~0.0.9"
+  },
+  "homepage": "https://github.com/koopjs/koop-sample-app",
+  "keywords": [
+    "agol",
+    "arcgis",
+    "etl",
+    "example",
+    "geojson",
+    "gis",
+    "heroku",
+    "koop",
+    "sample"
+  ],
+  "license": "ISC",
+  "main": "server.js",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com:koopjs/koop-sample-app.git"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,191 +1,197 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Koop</title>
+<head>
+  <title>Koop Sample App</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css">
+  <style>
+    .main {
+      margin: 2em auto;
+      max-width: 800px;
+    }
+    .input-group { margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container main">
+    <div class="page-header">
+      <h2> Koop <small>v<%= status.version %></small></h2>
+    </div>
 
-    <!-- Viewport mobile tag for sensible mobile support -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-    
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" media="all" rel="stylesheet" />
+    <p class="lead">Koop takes data from providers like providers like ArcGIS Online, CKAN, Socrata, and Github, and serves it as <a href="http://geojson.org">GeoJSON</a> and <a href="http://maps.esri.com/apl4/sdk/rest/featureserver.html">Feature Services</a>.</p>
 
-  </head>
+    <p class="lead">This allows users to query, map, or analyze data from many different sources using the Feature Service API and to easily download that data as GeoJSON.</p>
 
-  <body>
+    <h3>Providers</h3>
 
-    <!-- Javascripts from your assets folder are included here -->
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <hr>
 
+    <h4>Gists</h4>
 
-    <div class="container" style="padding:10px;">
-      <div class="page-header">
-        <h2> Koop <small>GeoJSON as FeatureServices</small></h2>
-      </div>
-      <div class="container">
-        <div class="container">
-          <div class="row">
-            <div class="col-4">
-              <div class="container">
-                <h2>View a Gist</h2>
-                <input type="text" id="gist" class="sample-input form-control" value="6178185" placeholder="Enter a gist id">
-                <button class="btn btn-primary pull-right" onClick="submitGist()">Map Gist</button>
-              </div>
-            </div>
-            <div class="col-4">
-              <div class="container">
-                <h2>or GitHub GeoJSON</h2>
-                <input type="text" id="github" class="sample-input form-control" value="chelm/grunt-geo/forks" placeholder="Path to a geojson file: user/repo/file">
-                <button class="btn btn-primary pull-right" onClick="submitGithub()">Map GitHub</button>
-              </div>
-            </div>
+    <p>Gists are accessed by adding the id to <code>/gist/:gist_id</code>, and optionally the Feature Service metadata or query. For example:</p>
+
+    <ul>
+      <li>Raw GeoJSON: <a href="/gist/6021269/">/gist/6021269</a></li>
+      <li>FeatureService: <a href="/gist/6021269/FeatureServer/0">/gist/6021269/FeatureServer/0</a></li>
+      <li>Query: <a href="/gist/6021269/FeatureServer/0/query">/gist/6021269/FeatureServer/0/query</a></li>
+    </ul>
+
+    <h4>Github</h5>
+
+    <p>Files from Github are accessed with the following pattern: <code>http://:hostname/github/:username/:repository/:path</code></p>
+
+    <ul>
+      <li>Raw GeoJSON: <a href="/github/chelm/grunt-geo/forks">/github/chelm/grunt-geo/forks</a></li>
+      <li>FeatureService: <a href="/github/chelm/grunt-geo/forks/FeatureServer/0">/github/chelm/grunt-geo/forks/FeatureServer/0</a></li>
+      <li>Query: <a href="/github/chelm/grunt-geo/forks/FeatureServer/0/query">/github/chelm/grunt-geo/forks/FeatureServer/0/query</a></li>
+      <strong>NOTE</strong>: <code>path</code> parameter uses "::" as the sub-directory seperator. So for example if the file is at <code>github.com/chelm/grunt-geo/tree/master/samples/bower.geojson</code> then the Koop path would look like:
+        <a href="/github/chelm/grunt-geo/samples::bower">/github/chelm/grunt-geo/samples::bower</a>
+    </ul>
+
+    <h3>Previews</h3>
+
+    <hr>
+
+    <p>Koop can preview any gist or github file using the simple view endpoints:</p>
+
+    <ul>
+      <li>Gist: <a href="/gist">/gist</a></li>
+      <li>Github: <a href="/github">/github</a></li>
+    </ul>
+
+    <h4>Try it out!</h4>
+
+    <div class="input-group">
+      <input type="text" id="gist" class="form-control" value="6178185" placeholder="Enter a gist id">
+      <span class="input-group-btn">
+        <button class="btn btn-primary" onClick="submitGist()">Map Gist</button>
+      </span>
+    </div>
+
+    <div class="input-group">
+      <input type="text" id="github" class="form-control" value="chelm/grunt-geo/forks" placeholder="Path to a geojson file: user/repo/file">
+      <span class="input-group-btn">
+        <button class="btn btn-primary" onClick="submitGithub()">Map GitHub</button>
+      </span>
+    </div>
+
+    <h3>Spatial Queries</h3>
+
+    <hr>
+
+    <p>Example:</p>
+
+    <pre><code><a href="http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?geometry=-180,-90,180,90">http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?geometry=-180,-90,180,90</a></code></pre>
+
+    <h3>Filter Queries</h3>
+
+    <hr>
+
+    <p>Example:</p>
+
+    <pre><code><a href='http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?where=ZIP=60647'>http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?where=ZIP=60647</a></code></pre>
+
+    <h3>Query parameters</h3>
+
+    <hr>
+
+    <div class="accordion" id="accordion2">
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_id">idField*</a>
+        </div>
+        <div id="collapse_id" class="accordion-body collapse">
+          <div class="accordion-inner">
+            * the params is specific to koop and is not part of the FeatureService spec
+            specifies what field to use as the ObjectID field
+            <ul><li><a href="/gist/6021269/FeatureServer/0/query?idField=id">/geojson/snow/FeatureServer/0/query?idField=id</a></li></ul>
           </div>
         </div>
-        <div class="container">
-          <h2>Docs</h2>
-          <hr/>
-          <p>Koop serves both <a href="http://geojson.org" target="_blank">GeoJSON</a> and <a href="http://maps.esri.com/apl4/sdk/rest/featureserver.html" target="_blank">GeoServices Feature Service</a> from shared <a href="http://gist.github.com" target="_blank">Gists</a> and  public <a href="http://github.com">GitHub</a> repositories. This allows you to Query, Map, or Analyze GeoJSON files just like they were a full API service. </p>
-          <!--h3>Endpoints</h3>
-            <p>The generic pattern for a Koop endpoint is <code>host/(gist id or github repo)/FeatureServer/layer/query</code>
-            <ul>
-            <li>Service metadata: host/resource/FeatureServer</li>
-            <li>Layer metadata: host/resource/FeatureServer/0</li>
-            <li>Layer queries: host/resource/FeatureServer/query</li>
-            </ul-->
-    
-          <h3>Gists</h3>
-            Gists are accessed by adding the id to <code>/gist/:gist_id</code>, and optionally the Feature Service metadata or query. For example:
-            <ul>
-              <li>Raw GeoJSON: <a href="/gist/6021269/" target="_blank">/gist/6021269</a></li>
-              <li>FeatureService: <a href="/gist/6021269/FeatureServer/0" target="_blank">/gist/6021269/FeatureServer/0</a></li>
-              <li>Query: <a href="/gist/6021269/FeatureServer/0/query" target="_blank">/gist/6021269/FeatureServer/0/query</a></li>
-            </ul>
-          <h3>Github</h3>
-            Files from Github are accessed with the endpoint <code>/github/:username/:repository/:path</code>
-            <ul>
-              <li>Raw GeoJSON: <a href="/github/chelm/grunt-geo/forks" target="_blank">/github/chelm/grunt-geo/forks</a></li>
-              <li>FeatureService: <a href="/github/chelm/grunt-geo/forks/FeatureServer/0" target="_blank">/github/chelm/grunt-geo/forks/FeatureServer/0</a></li>
-              <li>Query: <a href="/github/chelm/grunt-geo/forks/FeatureServer/0/query" target="_blank">/github/chelm/grunt-geo/forks/FeatureServer/0/query</a></li>
-              <strong>NOTE</strong>: <code>path</code> parameter uses "::" as the sub-directory seperator. So for example if the file is at <code>github.com/chelm/grunt-geo/tree/master/samples/bower.geojson</code> then the Koop path would look like:
-                <a href="/github/chelm/grunt-geo/samples::bower" target="_blank">/github/chelm/grunt-geo/samples::bower</a>
-            </ul>
-    
-          <h3>Previews</h3>
-            Koop can preview any gist or github file using the simple view endpoints:
-            <ul>
-              <li>Gist: <a href="/gist" target="_blank">/gist</a></li>
-              <li>Github: <a href="/github" target="_blank">/github</a></li>
-            </ul>
-    
-          <h3>Spatial Queries</h3>
-    
-            <li><a href="http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?geometry=-180,-90,180,90" target="_blank">http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?geometry=-180,-90,180,90</a></li>
-    
-          <h3>Filter Queries</h3>
-            
-            <li><a href='http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?where=ZIP=60647' target="_blank">http://koop.dc.esri.com/github/smartchicago/chicago-atlas/db::import::zipcodes/FeatureServer/0/query?where=ZIP=60647</a></li>
-    
-          <h3>Query parameters</h3>
-            <div class="accordion" id="accordion2">
-              <div class="accordion-group">
-                <div class="accordion-heading">
-                  <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_id">
-                    idField*
-                  </a>
-                </div>
-                <div id="collapse_id" class="accordion-body collapse">
-                  <div class="accordion-inner">
-                    * the params is specific to koop and is not part of the FeatureService spec
-                    specifies what field to use as the ObjectID field
-                    <ul><li><a href="/gist/6021269/FeatureServer/0/query?idField=id">/geojson/snow/FeatureServer/0/query?idField=id</a></li></ul>
-                  </div>
-                </div>
-              </div>
-              <div class="accordion-group">
-                <div class="accordion-heading">
-                  <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_objectid">
-                    objectIds
-                  </a>
-                </div>
-                <div id="collapse_objectid" class="accordion-body collapse">
-                  <div class="accordion-inner">
-                    returns only the features that match a given objectId
-                    <ul><li><a href="/gist/6021269/FeatureServer/0/query?objectIds=1,2,3">/geojson/snow/FeatureServer/0/query?objectIds=1,2,3</a></li></ul>
-                  </div>
-                </div>
-              </div>
-              <div class="accordion-group">
-                <div class="accordion-heading">
-                  <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_returncountonly">
-                    returnCountOnly (true or false)
-                  </a>
-                </div>
-                <div id="collapse_returncountonly" class="accordion-body collapse">
-                  <div class="accordion-inner">
-                    if true, returns only the count of features that would be returned based on other query params
-                    <ul><li><a href="/gist/6021269/FeatureServer/0/query?returnCountOnly=true">/geojson/snow/FeatureServer/0/query?returnCountOnly=true</a></li></ul>
-                  </div>
-                </div>
-              </div>
-              <div class="accordion-group">
-                <div class="accordion-heading">
-                  <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_returnidsonly">
-                    returnIdsOnly (true or false)
-                  </a>
-                </div>
-                <div id="collapse_returnidsonly" class="accordion-body collapse">
-                  <div class="accordion-inner">
-                    returns only the Ids of the feature that would be returned based on other params
-                    <ul><li><a href="/gist/6021269/FeatureServer/0/query?returnIdsOnly=true">/geojson/snow/FeatureServer/0/query?returnIdsOnly=true</a></li></ul>
-                  </div>
-                </div>
-              </div>
-              <div class="accordion-group">
-                <div class="accordion-heading">
-                  <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_geometry">
-                    geometry (xmin,ymin,xmax,ymax)
-                  </a>
-                </div>
-                <div id="collapse_geometry" class="accordion-body collapse">
-                  <div class="accordion-inner">
-                    sets a geometry filter and returns only features that are within the given geometry
-                    <ul><li><a href="/gist/6021269/FeatureServer/0/query?geometry=-110,30,-106,50">/geojson/snow/FeatureServer/0/query?geometry=-110,30,-106,50</a></li></ul>
-                  </div>
-                </div>
-              </div>
-            </div>
+      </div>
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_objectid">objectIds</a>
+        </div>
+        <div id="collapse_objectid" class="accordion-body collapse">
+          <div class="accordion-inner">
+            returns only the features that match a given objectId
+            <ul><li><a href="/gist/6021269/FeatureServer/0/query?objectIds=1,2,3">/geojson/snow/FeatureServer/0/query?objectIds=1,2,3</a></li></ul>
+          </div>
         </div>
       </div>
-    <div>
-    
-    <script>
-    
-      function submitGist(){
-        var val = document.getElementById('gist').value;
-        if ( val ) {
-          go( '/gist/' + val + '/preview' );
-        }
-      }
-    
-      function submitGithub(){
-        var val = document.getElementById('github').value.split('/');
-        var user = val.shift();
-        var repo = val.shift();
-        if ( val.length > 1){
-          var path = val.join('::');
-        } else {
-          var path = val[0];
-        }
-        if ( user && repo && path ) {
-          go( '/github/' + [ user, repo, path ].join('/') + '/preview' );
-        }
-      }
-    
-      function go( path ){
-        location.href = path;
-      }
-    
-    </script>
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_returncountonly">returnCountOnly (true or false)</a>
+        </div>
+        <div id="collapse_returncountonly" class="accordion-body collapse">
+          <div class="accordion-inner">
+            if true, returns only the count of features that would be returned based on other query params
+            <ul><li><a href="/gist/6021269/FeatureServer/0/query?returnCountOnly=true">/geojson/snow/FeatureServer/0/query?returnCountOnly=true</a></li></ul>
+          </div>
+        </div>
+      </div>
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_returnidsonly">returnIdsOnly (true or false)</a>
+        </div>
+        <div id="collapse_returnidsonly" class="accordion-body collapse">
+          <div class="accordion-inner">
+            returns only the Ids of the feature that would be returned based on other params
+            <ul><li><a href="/gist/6021269/FeatureServer/0/query?returnIdsOnly=true">/geojson/snow/FeatureServer/0/query?returnIdsOnly=true</a></li></ul>
+          </div>
+        </div>
+      </div>
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#collapse_geometry">
+            geometry (xmin,ymin,xmax,ymax)
+          </a>
+        </div>
+        <div id="collapse_geometry" class="accordion-body collapse">
+          <div class="accordion-inner">
+            sets a geometry filter and returns only features that are within the given geometry
+            <ul><li><a href="/gist/6021269/FeatureServer/0/query?geometry=-110,30,-106,50">/geojson/snow/FeatureServer/0/query?geometry=-110,30,-106,50</a></li></ul>
+          </div>
+        </div>
+      </div>
+    </div>
 
+    <hr>
+
+    <p>See the Koop <a href="https://github.com/esri/koop#readme">README</a> for more information.</p>
+
+  <div>
+
+  <script type="text/javascript" src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script type="text/javascript" src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+  <script>
+    function submitGist () {
+      var val = document.getElementById('gist').value;
+      if (val) {
+        go('/gist/' + val + '/preview');
+      }
+    }
+
+    function submitGithub () {
+      var val = document.getElementById('github').value.split('/');
+      var user = val.shift();
+      var repo = val.shift();
+
+      if (val.length > 1) {
+        var path = val.join('::');
+      } else {
+        var path = val[0];
+      }
+
+      if (user && repo && path) {
+        go('/github/' + [ user, repo, path ].join('/') + '/preview');
+      }
+    }
+
+    function go (path) {
+      location.href = path;
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Got rid of some unnecessary things, cleaned up code, improved package.json, lots of housekeeping basically. Should be more straightforward and have more parity with express examples and conventions than before.

@chelm I'm unable to get previews working locally at this point. Getting the following errors with what's provided in the default `index.ejs`

with `http://localhost:1337/gist/6178185/preview`

```
ReferenceError: /Users/nate/dev/github/koop-sample-app/node_modules/koop-gist/views/demo.ejs:65
   63|         $('#'+mapDom).css({ width:document.width, height: document.height });
   64|         var koop = koopMap( mapDom );
>> 65|         koop.add(location.origin + '/gist/' + '<%= id %>' + '/FeatureServer/0');
   66|       });
   67| 
   68|     </script>

id is not defined
   at eval (eval at <anonymous> (/Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:455:12), <anonymous>:9:28)
   at /Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:482:14
   at View.exports.renderFile [as engine] (/Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:348:31)
   at View.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/view.js:93:8)
   at EventEmitter.app.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/application.js:566:10)
   at ServerResponse.res.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/response.js:938:7)
   at controller.preview (/Users/nate/dev/github/koop-sample-app/node_modules/koop-gist/controller/index.js:108:9)
   at Layer.handle [as handle_request] (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/layer.js:82:5)
   at next (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/route.js:110:13)
   at Route.dispatch (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/route.js:91:3)
```

with `http://localhost:1337/github/chelm/grunt-geo/forks/preview`

```
ReferenceError: /Users/nate/dev/github/koop-sample-app/node_modules/koop-github/views/demo.ejs:63
   61|         $('#'+mapDom).css({ width:document.width, height: document.height });
   62|         var koop = koopMap( mapDom );
>> 63|         koop.add(location.origin + '/github/<%= user %>/<%= repo %>/<%= file %>/FeatureServer/0');
   64|       });
   65|     </script>
   66|   </body>

user is not defined
   at eval (eval at <anonymous> (/Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:455:12), <anonymous>:9:28)
   at /Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:482:14
   at View.exports.renderFile [as engine] (/Users/nate/dev/github/koop-sample-app/node_modules/ejs/lib/ejs.js:348:31)
   at View.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/view.js:93:8)
   at EventEmitter.app.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/application.js:566:10)
   at ServerResponse.res.render (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/response.js:938:7)
   at controller.preview (/Users/nate/dev/github/koop-sample-app/node_modules/koop-github/controller/index.js:195:10)
   at Layer.handle [as handle_request] (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/layer.js:82:5)
   at next (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/route.js:110:13)
   at Route.dispatch (/Users/nate/dev/github/koop-sample-app/node_modules/express/lib/router/route.js:91:3)
```