### PR TITLE
Update the sample app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 6
+  - 10
 sudo: false # Enable docker-based containers
 cache:
   directories: # Cache dependencies

--- a/README.md
+++ b/README.md
@@ -39,19 +39,14 @@ Take Koop for a test drive!
 
 This sample app includes the following providers:
 
-* [`agol`](https://github.com/koopjs/koop-provider-agol)
-* [`zillow`](https://github.com/dmfenton/koop-provider-zillow)
+* [`github`](https://github.com/koopjs/koop-provider-github)
 * [`craigslist`](https://github.com/dmfenton/koop-provider-craigslist)
 
-Optional:
+Once Koop is running, you can test these sample requests:
 
-To configure the provider below:
+* [http://localhost:8080/github/koopjs::geodata::north-america/FeatureServer/0/query](http://localhost:8080/github/koopjs::geodata::north-america/FeatureServer/0/query)
+* [http://localhost:8080/craigslist/seattle/apartments/FeatureServer/0/query](http://localhost:8080/craigslist/seattle/apartments/FeatureServer/0/query)
 
-* [`trimet`](https://github.com/koopjs/koop-provider-trimet)
-
-1. sign up for a [developer key](https://developer.trimet.org/appid/registration/)
-2. reference it in `/koop-provider-trimet/config/default.json`
-3. copy/paste the file into `/koop-sample-app/config/`
 
 ## Deploying
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
     "url": "https://github.com/koopjs/koop-sample-app/issues"
   },
   "dependencies": {
-    "config": "^2.0.0",
-    "koop": "^3.5.0",
-    "koop-provider-agol": "^3.14.4",
-    "koop-provider-craigslist": "^2.0.0",
-    "koop-provider-trimet": "^2.0.1",
-    "koop-provider-zillow": "^1.0.0"
+    "@koopjs/provider-github": "^3.0.0",
+    "config": "^2.0.1",
+    "koop": "^3.10.0",
+    "koop-provider-craigslist": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^11.0.0",

--- a/server.js
+++ b/server.js
@@ -3,16 +3,12 @@ const Koop = require('koop')
 const koop = new Koop(config)
 
 // providers
-const agol = require('koop-provider-agol')
-const zillow = require('koop-provider-zillow')
+const github = require('@koopjs/provider-github')
 const craigslist = require('koop-provider-craigslist')
-// const trimet = require('koop-provider-trimet')
 
 // register koop providers
-koop.register(agol)
-koop.register(zillow)
+koop.register(github)
 koop.register(craigslist)
-// koop.register(trimet)
 
 // This is how you implement additional arbitrary routes on the Koop server
 koop.server.get('/', function (req, res) {
@@ -20,11 +16,9 @@ koop.server.get('/', function (req, res) {
 Welcome to Koop!
 
 Installed Providers:
-ArcGIS Online
-Zillow
+Github
 Craigslist
 
-Portland TriMet isn't configured (yet)
 `)
 })
 


### PR DESCRIPTION
Slimmed this down to two providers, github and craigslist, as they are the most recently maintained and require no configuration.  Updated the readme and bumped Travis node to 10.